### PR TITLE
Update README for landing page usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,48 @@
-# React + TypeScript + Vite
+# Nodo Landing Page
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project contains the source for a marketing landing page built with **React**, **TypeScript**, **Vite** and **Tailwind CSS**. The page showcases Nodo's features and partners using a set of styled sections and custom components.
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js 18 or later
+- npm (comes with Node.js)
 
-## Expanding the ESLint configuration
+## Installation
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+Install the dependencies once Node.js is available:
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Development
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Start the development server with hot reloading:
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev
 ```
+
+The page will be served at [http://localhost:5173](http://localhost:5173) by default.
+
+## Production Build
+
+Generate an optimized build in the `dist` directory:
+
+```bash
+npm run build
+```
+
+You can preview the build locally with:
+
+```bash
+npm run preview
+```
+
+## Image Assets
+
+Local SVG assets are stored under `src/assets`. Many of the larger illustrations are referenced from URLs exported from Figma (e.g. `http://localhost:3845/assets/...`). Ensure those resources are reachable when running or building the site, otherwise placeholder images may appear.
+
+## Notes
+
+The repository also contains an ESLint configuration (`npm run lint`) which currently reports an issue in `src/components/ui/button.tsx`. Linting is optional for running and building the page.


### PR DESCRIPTION
## Summary
- rewrite README with instructions for the landing page

## Testing
- `npm run build`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components)*

------
https://chatgpt.com/codex/tasks/task_e_687e00f7771c832e9e6c4b7a5a28aeee