### PR TITLE
refactor: centralize asset URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_ASSET_BASE_URL=http://localhost:3845

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,6 @@
 import { Button } from './ui/button'
 import { motion } from 'framer-motion'
-
-// NODO logo asset
-const imgNodoLogo = "data:image/svg+xml,%3Csvg width='43' height='14' viewBox='0 0 43 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.5 0L17 7L8.5 14L0 7L8.5 0Z' fill='%23FF6B35'/%3E%3Cpath d='M25.5 0L34 7L25.5 14L17 7L25.5 0Z' fill='%23FF6B35'/%3E%3C/svg%3E"
+import { NODO_LOGO_DATA_URI } from '../config/assets'
 
 export default function Header() {
   return (
@@ -17,13 +15,13 @@ export default function Header() {
           {/* Logo and Navigation */}
           <div className="flex items-center gap-4 sm:gap-6 md:gap-8 lg:gap-12 xl:gap-16">
             {/* NODO Logo */}
-            <div className="w-16 sm:w-20 md:w-24 lg:w-28 xl:w-32 h-8 sm:h-10 md:h-12 lg:h-14 xl:h-16 relative">
-              <img
-                src={imgNodoLogo}
-                alt="NODO"
-                className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full object-contain"
-              />
-            </div>
+              <div className="w-16 sm:w-20 md:w-24 lg:w-28 xl:w-32 h-8 sm:h-10 md:h-12 lg:h-14 xl:h-16 relative">
+                <img
+                  src={NODO_LOGO_DATA_URI}
+                  alt="NODO"
+                  className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full h-full object-contain"
+                />
+              </div>
 
             {/* Navigation */}
             <div className="hidden md:flex items-center h-12 lg:h-14 xl:h-16 relative">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,9 +1,9 @@
 import { motion } from 'framer-motion'
-
-// Hero assets
-const imgHeroSphere = "http://localhost:3845/assets/256c608c492172c86679879aeb543ec2e58eee83.png"
-const imgHeroSphereMask = "http://localhost:3845/assets/3d7097266995ad1044f383915d0035b49c212f55.svg"
-const imgEllipseGlow = "http://localhost:3845/assets/b45acdf9e2603fbcea02f24aa2350113bbb296de.svg"
+import {
+  HERO_SPHERE_IMAGE_URL,
+  HERO_SPHERE_MASK_URL,
+  HERO_ELLIPSE_GLOW_URL,
+} from '../config/assets'
 
 export default function HeroSection() {
   return (
@@ -11,7 +11,11 @@ export default function HeroSection() {
       {/* Background glow */}
       <div className="hidden lg:block absolute left-[1018px] top-[210px] w-glow h-glow">
         <div className="absolute inset-0 -scale-[4]">
-          <img alt="Background glow" className="block max-w-none w-full h-full" src={imgEllipseGlow} />
+          <img
+            alt="Background glow"
+            className="block max-w-none w-full h-full"
+            src={HERO_ELLIPSE_GLOW_URL}
+          />
         </div>
       </div>
 
@@ -72,15 +76,15 @@ export default function HeroSection() {
             <div
               className="absolute inset-0 bg-cover bg-center bg-no-repeat"
               style={{
-                backgroundImage: `url('${imgHeroSphere}')`,
-                maskImage: `url('${imgHeroSphereMask}')`,
+                backgroundImage: `url('${HERO_SPHERE_IMAGE_URL}')`,
+                maskImage: `url('${HERO_SPHERE_MASK_URL}')`,
                 maskSize: 'contain'
               }}
             />
             <div
               className="absolute inset-0 bg-gradient-to-r from-[#FF00A6] via-[#FF00C8] via-[#FF00FF] via-[#C400FF] via-[#4A28FF] via-[#002FFF] via-[#0078FF] via-[#00C4FF] to-[#00FFFF] mix-blend-hue"
               style={{
-                maskImage: `url('${imgHeroSphereMask}')`,
+                maskImage: `url('${HERO_SPHERE_MASK_URL}')`,
                 maskSize: 'contain',
                 maskPosition: 'center'
               }}

--- a/src/config/assets.ts
+++ b/src/config/assets.ts
@@ -1,0 +1,7 @@
+export const ASSET_BASE_URL = import.meta.env.VITE_ASSET_BASE_URL ?? ''
+
+export const NODO_LOGO_DATA_URI = "data:image/svg+xml,%3Csvg width='43' height='14' viewBox='0 0 43 14' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.5 0L17 7L8.5 14L0 7L8.5 0Z' fill='%23FF6B35'/%3E%3Cpath d='M25.5 0L34 7L25.5 14L17 7L25.5 0Z' fill='%23FF6B35'/%3E%3C/svg%3E"
+
+export const HERO_SPHERE_IMAGE_URL = `${ASSET_BASE_URL}/assets/256c608c492172c86679879aeb543ec2e58eee83.png`
+export const HERO_SPHERE_MASK_URL = `${ASSET_BASE_URL}/assets/3d7097266995ad1044f383915d0035b49c212f55.svg`
+export const HERO_ELLIPSE_GLOW_URL = `${ASSET_BASE_URL}/assets/b45acdf9e2603fbcea02f24aa2350113bbb296de.svg`


### PR DESCRIPTION
## Summary
- centralize asset URLs and logo data in config
- wire Header and HeroSection to use shared asset constants
- add .env.example for asset base URL

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899574cffb0832e97d297d9f14e11a5